### PR TITLE
[Fix] Handle 401 requests

### DIFF
--- a/src/lib/services/backendService.ts
+++ b/src/lib/services/backendService.ts
@@ -55,7 +55,7 @@ function createBackendService() {
         return Promise.reject(error);
       }
 
-      // Get original request so we can retry it after refreshing our tokens
+      // Get original request, so we can retry it after refreshing our tokens
       const originalRequest: OriginalRequest = error.config;
 
       if (originalRequest._doNotRefresh) {
@@ -96,6 +96,9 @@ function createBackendService() {
       // }
 
       clearAuthCookies();
+
+      window.location.pathname = '/login';
+
       return Promise.reject(error);
     },
   );


### PR DESCRIPTION
## Summary
Redirects to `/login` upon `401` response.
When user gets `401` response, it means that user is not authenticated.

> [!NOTE]
> We'll upgrade this with introduction of refresh tokens.

> [!WARNING]
> Still missing BE update on this one. BE needs to return `401` if access token is invalid or not present.