### PR TITLE
Merge to production

### DIFF
--- a/src/pages-components/Dashboard/FleetPage/Vans/VansPage/VansTable.tsx
+++ b/src/pages-components/Dashboard/FleetPage/Vans/VansPage/VansTable.tsx
@@ -49,6 +49,16 @@ export const VansTable = ({ vans }: { vans: Vehicle[] }) => {
         cell: ({ row }) => {
           const { vehicleLoadType } = row.original;
 
+          if(!vehicleLoadType) {
+            return (
+              <FlexLayout>
+                <Text className="text-color-2">
+                  –
+                </Text>
+              </FlexLayout>
+            );
+          }
+
           return (
             <FlexLayout>
               <Text className="text-color-2 group-hover/cell:text-teal-600 capitalize">


### PR DESCRIPTION
## Summary

### Hotfixes 🔥🐞 
- Fixes `VansTable`: `vehicleLoadType: null` breaks the page.