### PR TITLE
[Fix] Shipment form - Init sub shipment

### DIFF
--- a/src/pages-components/Dashboard/ShipmentsPage/NewShipmentPage/CargoField.tsx
+++ b/src/pages-components/Dashboard/ShipmentsPage/NewShipmentPage/CargoField.tsx
@@ -94,7 +94,10 @@ export const CargoField = ({ index, cargoLength }: CargoFieldProps) => {
   }
 
   return (
-    <FlexLayout as="fieldset" className="flex-col max-h-max gap-4 bg-dark-100 dark:bg-white-alpha-10 p-4 rounded-s">
+    <FlexLayout
+      as="fieldset"
+      className="flex-col max-h-max min-w-0 gap-4 bg-dark-100 dark:bg-white-alpha-10 p-4 rounded-s"
+    >
       <FlexLayout className="justify-between items-center">
         <Text color="text-color-3" variant="text-s-medium">
           TERET {index + 1}

--- a/src/pages-components/Dashboard/ShipmentsPage/NewShipmentPage/CargoFieldList.tsx
+++ b/src/pages-components/Dashboard/ShipmentsPage/NewShipmentPage/CargoFieldList.tsx
@@ -11,7 +11,7 @@ export const CargoFieldList = () => {
   const cargo = watch('cargo');
 
   return (
-    <FlexLayout className="flex-1 flex-col gap-4">
+    <FlexLayout className="flex-1 flex-col gap-4 min-w-0">
       <Text color="text-color-2" variant="text-l-medium">
         Tereti
       </Text>

--- a/src/pages-components/Dashboard/ShipmentsPage/NewShipmentPage/CargoLoadField/CargoLoadField.tsx
+++ b/src/pages-components/Dashboard/ShipmentsPage/NewShipmentPage/CargoLoadField/CargoLoadField.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { getDataPointDateString } from '@/lib/utils/date';
 import { getCountryFromCode } from '@/pages-components/Dashboard/NewEmployeePage/const';
-import { Box, Collapsible, DisplayIf, Divider, FlexLayout, Text, TextButton } from '@/ui';
+import { Collapsible, DisplayIf, Divider, FlexLayout, Text, TextButton } from '@/ui';
 
 import { useHasCargoLoads } from '../hooks/useHasCargoLoads';
 import { CargoLoadModal } from './CargoLoadModal';
@@ -80,21 +80,15 @@ export const CargoLoadField: React.FC<CargoLoadFieldProps> = ({ cargo, type, onC
   return (
     <>
       {!initialValues.address?.streetName ? (
-        <FlexLayout className="items-center gap-4">
-          <Box className="flex-1">
-            <TextButton iconLeft="PlusIcon" text={addLabel} type="button" variant="primary" onClick={openModal} />
-          </Box>
+        <FlexLayout className="min-w-0 flex-1 flex-col justify-center gap-4">
+          <TextButton iconLeft="PlusIcon" text={addLabel} type="button" variant="primary" onClick={openModal} />
           <DisplayIf condition={hasCargoLoads}>
-            <Box className="flex-1">
-              <Divider text="Ili" />
-            </Box>
-            <Box className="w-1/2 shrink-0">
-              <LoadSelect onChange={onChange} />
-            </Box>
+            <Divider text="Ili" />
+            <LoadSelect onChange={onChange} />
           </DisplayIf>
         </FlexLayout>
       ) : (
-        <FlexLayout className="flex-1 flex-col gap-4">
+        <FlexLayout className="flex-1 flex-col gap-4 min-w-0">
           <FlexLayout className="gap-2 items-center">
             <Text
               className="underline underline-offset-2 decoration-2 decoration-teal-600 dark:decoration-teal-500"

--- a/src/pages-components/Dashboard/ShipmentsPage/NewShipmentPage/utils.ts
+++ b/src/pages-components/Dashboard/ShipmentsPage/NewShipmentPage/utils.ts
@@ -1,4 +1,4 @@
-import { type CreateShipmentData, getShipment, type Shipment } from '@/lib/api';
+import { type CreateShipmentData, type Shipment } from '@/lib/api';
 import { getPostalCode } from '@/lib/api/postalCodes';
 import type { Tenant } from '@/lib/api/tenant.d';
 import { PalleteType } from '@/lib/utils/palletes';
@@ -116,17 +116,6 @@ const mapCargoItems = async (cargoItems?: any[], isEdit = false): Promise<Cargo[
   );
 };
 
-// Get cargo items from parent shipment
-const getParentShipmentCargo = async (parentShipmentId: string): Promise<Cargo[]> => {
-  try {
-    const parentShipment = await getShipment(parentShipmentId);
-    return mapCargoItems(parentShipment.cargo);
-  } catch (error) {
-    console.error('Error fetching parent shipment cargo:', error);
-    return [defaultCargo];
-  }
-};
-
 // Create form values for a new shipment
 const getNewShipmentFormValues = async (tenant: Tenant, cargo: Cargo[]) => {
   return {
@@ -138,14 +127,12 @@ const getNewShipmentFormValues = async (tenant: Tenant, cargo: Cargo[]) => {
 };
 
 // Create form values for a new sub-shipment
-const getNewSubShipmentFormValues = async (tenant: Tenant, parentShipmentId: string) => {
-  const cargo = await getParentShipmentCargo(parentShipmentId);
-
+const getNewSubShipmentFormValues = async (tenant: Tenant) => {
   return {
     ...formDefaultValues,
     transportContractorId: tenant.id,
     clientId: tenant.id,
-    cargo,
+    cargo: [{ ...defaultCargo }],
   };
 };
 
@@ -203,7 +190,7 @@ export const getFormDefaultValues = (
 
     // Case 3: Create a sub-shipment
     if (parentShipmentId) {
-      return getNewSubShipmentFormValues(tenant, parentShipmentId);
+      return getNewSubShipmentFormValues(tenant);
     }
 
     // Case 4: Create a brand-new shipment

--- a/src/pages-components/Dashboard/ShipmentsPage/SingleShipmentPage/SingleShipmentPage.tsx
+++ b/src/pages-components/Dashboard/ShipmentsPage/SingleShipmentPage/SingleShipmentPage.tsx
@@ -105,7 +105,7 @@ const MainContent: React.FC<{ shipment: Shipment }> = ({ shipment }) => {
                 <Divider />
               </Box>
             </FlexLayout>
-            <FlexLayout as="section" className="flex-1 flex-col gap-4">
+            <FlexLayout as="section" className="flex-1 flex-col gap-4 min-w-0">
               <Text color="text-color-2" variant="text-l-medium">
                 Tereti
               </Text>

--- a/src/pages-components/Dashboard/ShipmentsPage/SingleShipmentPage/components/CargoItem.tsx
+++ b/src/pages-components/Dashboard/ShipmentsPage/SingleShipmentPage/components/CargoItem.tsx
@@ -152,7 +152,7 @@ const NonstandardContent = ({ cargo }: { cargo: CargoWithMetadata }) => {
 const LoadingFields = ({ cargo }: { cargo: CargoWithMetadata }) => {
   return (
     <FlexLayout as="section" className="justify-between gap-4">
-      <FlexLayout className="flex-1 flex-col gap-4">
+      <FlexLayout className="flex-1 flex-col gap-4 min-w-0">
         <FlexLayout className="gap-2 items-center">
           <Text
             className="underline underline-offset-2 decoration-2 decoration-teal-600 dark:decoration-teal-500"
@@ -198,7 +198,7 @@ const LoadingFields = ({ cargo }: { cargo: CargoWithMetadata }) => {
         <Collapsible description={cargo.loadingDescription} label="Napomena" />
       </FlexLayout>
       <VerticalDivider />
-      <FlexLayout className="flex-1 flex-col gap-4">
+      <FlexLayout className="flex-1 flex-col gap-4 min-w-0">
         <FlexLayout className="gap-2 items-center">
           <Text
             className="underline underline-offset-2 decoration-2 decoration-teal-600 dark:decoration-teal-500"

--- a/src/ui/components/Collapsible/Collapsible.tsx
+++ b/src/ui/components/Collapsible/Collapsible.tsx
@@ -18,7 +18,7 @@ export const Collapsible: React.FC<{ label: string; description: string | undefi
           </FlexLayout>
         </RadixCollapsible.Trigger>
         <RadixCollapsible.Content asChild>
-          <Text className="whitespace-pre-line" color="text-color-1" variant="text-s">
+          <Text className="whitespace-pre-line break-words" color="text-color-1" variant="text-s">
             {description || '—'}
           </Text>
         </RadixCollapsible.Content>


### PR DESCRIPTION
## Summary
- Fixes text and UI overflow for cargo description in `ShipmentForm` and `SingleShipment`.
- Fixes subshipment form data init.
  - Fixes form data init when adding new subshipment.
  - Previously, it copied all cargo data, which is not what we want.
  - Now we initialize it as new shipment (and parentShipmentId is retrieved in handleFormSubmit).