### PR TITLE
feat(vehicle stops): drag-and-drop reorder for undated stops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "cargo-navis-web",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/modifiers": "9.0.0",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
         "@floating-ui/react": "^0.26.25",
         "@headlessui/react": "^2.1.2",
         "@heroui/react": "^2.7.6",
@@ -1751,6 +1755,74 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "typecheck": "tsc --noEmit --incremental false --tsBuildInfoFile null"
   },
   "dependencies": {
+    "@dnd-kit/core": "6.3.1",
+    "@dnd-kit/modifiers": "9.0.0",
+    "@dnd-kit/sortable": "10.0.0",
+    "@dnd-kit/utilities": "3.2.2",
     "@floating-ui/react": "^0.26.25",
     "@headlessui/react": "^2.1.2",
     "@heroui/react": "^2.7.6",

--- a/src/components/reui/timeline.tsx
+++ b/src/components/reui/timeline.tsx
@@ -153,25 +153,29 @@ interface TimelineItemProps extends HTMLAttributes<HTMLDivElement> {
   separatorActive?: boolean;
 }
 
-function TimelineItem({ step, completed, separatorActive, className, ...props }: TimelineItemProps) {
-  const { activeStep } = useTimeline();
-  const isCompleted = completed ?? step <= activeStep;
-  const isNextCompleted = separatorActive ?? step < activeStep;
+const TimelineItem = forwardRef<HTMLDivElement, TimelineItemProps>(
+  ({ step, completed, separatorActive, className, style, ...props }, ref) => {
+    const { activeStep } = useTimeline();
+    const isCompleted = completed ?? step <= activeStep;
+    const isNextCompleted = separatorActive ?? step < activeStep;
 
-  return (
-    <FlexLayout
-      className={cn(
-        'group/timeline-item relative flex-1 flex-col group-data-[orientation=vertical]/timeline:not-last:pb-6',
-        className
-      )}
-      data-completed={isCompleted || undefined}
-      data-separator-active={isNextCompleted || undefined}
-      data-slot="timeline-item"
-      style={{ gap: '2px' }}
-      {...props}
-    />
-  );
-}
+    return (
+      <FlexLayout
+        className={cn(
+          'group/timeline-item relative flex-1 flex-col group-data-[orientation=vertical]/timeline:not-last:pb-6',
+          className
+        )}
+        data-completed={isCompleted || undefined}
+        data-separator-active={isNextCompleted || undefined}
+        data-slot="timeline-item"
+        ref={ref}
+        style={{ gap: '2px', ...style }}
+        {...props}
+      />
+    );
+  }
+);
+TimelineItem.displayName = 'TimelineItem';
 
 // TimelineSeparator
 function TimelineSeparator({ className, ...props }: HTMLAttributes<HTMLDivElement>) {

--- a/src/lib/api/vehicleStops.ts
+++ b/src/lib/api/vehicleStops.ts
@@ -53,6 +53,10 @@ export async function updateVehicleStop(id: string, data: UpdateVehicleStopParam
   return backend.patch<VehicleStop>(`/api/vehicle-stops/${id}`, data);
 }
 
+export async function rearrangeVehicleStop(id: string, data: { previousStopId: string | null }) {
+  return backend.patch<VehicleStop>(`/api/vehicle-stops/${id}/rearrange`, data);
+}
+
 export async function deleteVehicleStop(id: string) {
   return backend.delete<void>(`/api/vehicle-stops/${id}`);
 }

--- a/src/lib/hooks/api/vehicleStops.ts
+++ b/src/lib/hooks/api/vehicleStops.ts
@@ -10,6 +10,7 @@ import {
   getVehicleStopFileUrl,
   getVehicleStops,
   getVehicleStopsByVehicle,
+  rearrangeVehicleStop,
   sendVehicleStopMessage,
   uncompleteVehicleStop,
   updateVehicleStop,
@@ -66,6 +67,58 @@ export function useUpdateVehicleStop() {
     mutationFn: ({ id, data }: { id: string; data: UpdateVehicleStopParams }) => updateVehicleStop(id, data),
     onSuccess: () => {
       return queryClient.invalidateQueries({ queryKey: [QUERY_KEY], type: 'all' });
+    },
+  });
+}
+
+export function useRearrangeVehicleStop(vehicleId: string) {
+  const queryClient = useQueryClient();
+  const queryKey = [QUERY_KEY, 'paginated', vehicleId];
+
+  return useMutation({
+    mutationFn: ({ stopId, previousStopId }: { stopId: string; previousStopId: string | null }) =>
+      rearrangeVehicleStop(stopId, { previousStopId }),
+    onMutate: ({ stopId, previousStopId }) => {
+      const snapshot = queryClient.getQueriesData<InfiniteData<PaginatedResponse<VehicleStop>>>({ queryKey });
+
+      queryClient.setQueriesData<InfiniteData<PaginatedResponse<VehicleStop>>>({ queryKey }, (old) => {
+        if (!old) return old;
+        const flat = old.pages.flatMap((p) => p.data);
+        const moved = flat.find((s) => s.id === stopId);
+        if (!moved) return old;
+        const updated = { ...moved, previousStopId };
+        const without = flat.filter((s) => s.id !== stopId);
+        const anchorIndex = previousStopId ? without.findIndex((s) => s.id === previousStopId) : -1;
+        const insertAt = previousStopId ? (anchorIndex === -1 ? without.length : anchorIndex) : without.length;
+        const reordered = [...without.slice(0, insertAt), updated, ...without.slice(insertAt)];
+
+        let cursor = 0;
+        const pages = old.pages.map((p) => {
+          const next = reordered.slice(cursor, cursor + p.data.length);
+          cursor += p.data.length;
+          return { ...p, data: next };
+        });
+        return { ...old, pages };
+      });
+
+      void queryClient.cancelQueries({ queryKey });
+      return { snapshot };
+    },
+    onError: (_err, _vars, context) => {
+      context?.snapshot.forEach(([key, data]) => queryClient.setQueryData(key, data));
+    },
+    onSuccess: (updatedStop) => {
+      queryClient.setQueriesData<InfiniteData<PaginatedResponse<VehicleStop>>>(
+        { queryKey },
+        (old) =>
+          old && {
+            ...old,
+            pages: old.pages.map((p) => ({
+              ...p,
+              data: p.data.map((s) => (s.id === updatedStop.id ? updatedStop : s)),
+            })),
+          }
+      );
     },
   });
 }

--- a/src/pages-components/Dashboard/VehicleStopsPage/VehicleStopDetailPage/VehicleStopDetailPage.tsx
+++ b/src/pages-components/Dashboard/VehicleStopsPage/VehicleStopDetailPage/VehicleStopDetailPage.tsx
@@ -1,3 +1,20 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  DragOverlay,
+  type DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -7,7 +24,7 @@ import { PageTitle } from '@/components/PageTitle';
 import { Timeline } from '@/components/reui/timeline';
 import type { VehicleStop } from '@/lib/api/vehicleStops';
 import { useVehicles } from '@/lib/hooks';
-import { useDeleteVehicleStop, useVehicleStops } from '@/lib/hooks/api/vehicleStops';
+import { useDeleteVehicleStop, useRearrangeVehicleStop, useVehicleStops } from '@/lib/hooks/api/vehicleStops';
 import { showErrorToast, showSuccessToast } from '@/lib/utils/toast';
 import { Box, FlexLayout, Icon, Text } from '@/ui';
 
@@ -28,14 +45,54 @@ export const VehicleStopDetailPage = () => {
   } = useVehicleStops(vehicleId);
   const { data: vehicles, isLoading: isLoadingVehicles } = useVehicles();
   const { mutateAsync: deleteStop } = useDeleteVehicleStop();
+  const { mutate: rearrangeStop } = useRearrangeVehicleStop(vehicleId);
 
   const vehicle = useMemo(() => vehicles?.find((v) => v.id === vehicleId), [vehicles, vehicleId]);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingStop, setEditingStop] = useState<VehicleStop | undefined>(undefined);
   const [previousStop, setPreviousStop] = useState<VehicleStop | undefined>(undefined);
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
 
   const stops = useMemo(() => data?.pages.flatMap((p) => p.data) ?? [], [data]);
+  const activeDragStop = useMemo(
+    () => (activeDragId ? stops.find((s) => s.id === activeDragId) : undefined),
+    [activeDragId, stops]
+  );
+  const activeDragStep = activeDragStop ? stops.findIndex((s) => s.id === activeDragStop.id) + 1 : 0;
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveDragId(event.active.id as string);
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveDragId(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = stops.findIndex((s) => s.id === active.id);
+    const newIndex = stops.findIndex((s) => s.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const reordered = arrayMove(stops, oldIndex, newIndex);
+    const previousStopId = reordered[newIndex + 1]?.id ?? null;
+    rearrangeStop(
+      { stopId: active.id as string, previousStopId },
+      {
+        onSuccess: () => showSuccessToast({ title: 'Stanica premještena.' }),
+        onError: () => showErrorToast({ title: 'Greška prilikom premještanja stanice. Pokušajte ponovno.' }),
+      }
+    );
+  }
+
+  function handleDragCancel() {
+    setActiveDragId(null);
+  }
 
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -144,18 +201,37 @@ export const VehicleStopDetailPage = () => {
               </Text>
             </FlexLayout>
           </Box>
-          <Timeline className="w-full" defaultValue={stops.length} orientation="vertical">
-            {stops.map((stop, i) => (
-              <VerticalStopEntry
-                key={stop.id}
-                step={i + 1}
-                stop={stop}
-                onDelete={handleDelete}
-                onEdit={openEditModal}
-                onInsertBefore={() => openInsertBeforeModal(stops[i + 1])}
-              />
-            ))}
-          </Timeline>
+          <DndContext
+            collisionDetection={closestCenter}
+            sensors={sensors}
+            onDragCancel={handleDragCancel}
+            onDragEnd={handleDragEnd}
+            onDragStart={handleDragStart}
+          >
+            <Timeline className="w-full" defaultValue={stops.length}>
+              <SortableContext items={stops.map((s) => s.id)} strategy={verticalListSortingStrategy}>
+                {stops.map((stop, i) => (
+                  <VerticalStopEntry
+                    key={stop.id}
+                    step={i + 1}
+                    stop={stop}
+                    onDelete={handleDelete}
+                    onEdit={openEditModal}
+                    onInsertBefore={() => openInsertBeforeModal(stops[i + 1])}
+                  />
+                ))}
+              </SortableContext>
+            </Timeline>
+            <DragOverlay dropAnimation={null}>
+              {activeDragStop ? (
+                <Box className="bg-white dark:bg-black shadow-lg rounded-md opacity-90">
+                  <Timeline defaultValue={activeDragStep} orientation="vertical">
+                    <VerticalStopEntry isDragOverlay step={activeDragStep} stop={activeDragStop} />
+                  </Timeline>
+                </Box>
+              ) : null}
+            </DragOverlay>
+          </DndContext>
           <Box className="h-1" ref={sentinelRef} />
           {isFetchingNextPage && <StopSkeleton isLast />}
         </Box>

--- a/src/pages-components/Dashboard/VehicleStopsPage/VehicleStopDetailPage/VerticalStopEntry.tsx
+++ b/src/pages-components/Dashboard/VehicleStopsPage/VehicleStopDetailPage/VerticalStopEntry.tsx
@@ -1,3 +1,5 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 
@@ -31,16 +33,30 @@ import { VehicleStopFileUploadButton } from './VehicleStopFileUploadButton';
 interface VerticalStopEntryProps {
   stop: VehicleStop;
   step: number;
+  isDragOverlay?: boolean;
   onEdit?(stop: VehicleStop): void;
   onDelete?(stop: VehicleStop): void;
   onInsertBefore?(): void;
 }
 
-export const VerticalStopEntry = ({ stop, step, onEdit, onDelete, onInsertBefore }: VerticalStopEntryProps) => {
+export const VerticalStopEntry = ({
+  stop,
+  step,
+  isDragOverlay,
+  onEdit,
+  onDelete,
+  onInsertBefore,
+}: VerticalStopEntryProps) => {
   const isCompleted = isStopCompleted(stop);
   const { address, date, loadingCargos, unloadingCargos, documents } = stop;
   const hasLoading = loadingCargos.length > 0;
   const hasUnloading = unloadingCargos.length > 0;
+  const isDraggable = !date && !isCompleted;
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: stop.id,
+    disabled: !isDraggable || isDragOverlay,
+  });
 
   const { mutateAsync: deleteFile, isPending: isDeletingFile } = useDeleteVehicleStopFile(stop.id);
   const { mutateAsync: getDocumentUrl, isPending: isGettingDocumentUrl } = useGetVehicleStopFileUrl(stop.id);
@@ -113,11 +129,17 @@ export const VerticalStopEntry = ({ stop, step, onEdit, onDelete, onInsertBefore
 
   return (
     <TimelineItem
-      className="group/stop-entry relative"
+      className={clsx('group/stop-entry relative', isDragging && 'opacity-40')}
       completed={isCompleted}
+      ref={setNodeRef}
       separatorActive={isCompleted}
       step={step}
-      style={{ paddingLeft: '32px', paddingBottom: '78px' }}
+      style={{
+        paddingLeft: '32px',
+        paddingBottom: '78px',
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
     >
       <TimelineHeader>
         <TimelineSeparator
@@ -272,6 +294,15 @@ export const VerticalStopEntry = ({ stop, step, onEdit, onDelete, onInsertBefore
           <VehicleStopFileUploadButton id={stop.id} />
         </FlexLayout>
       </FlexLayout>
+      {isDraggable && !isDragOverlay && (
+        <Box
+          className="absolute -left-1 top-7 hidden group-hover/stop-entry:block cursor-grab active:cursor-grabbing touch-none"
+          {...attributes}
+          {...listeners}
+        >
+          <Icon className="text-dark-400 hover:text-teal-500 dark:text-light-300" icon="IconGripVertical" size="l" />
+        </Box>
+      )}
       {onInsertBefore && (
         <FlexLayout className="flex-col absolute hidden group-hover/stop-entry:flex justify-center -left-2 bottom-6">
           <FlexLayout


### PR DESCRIPTION
## Summary
- Add @dnd-kit/core, /sortable, /modifiers, /utilities.
- Add rearrangeVehicleStop API call and useRearrangeVehicleStop hook with optimistic cache update and rollback on error.
- Make VerticalStopEntry sortable with a grip handle shown only on hover for undated, not-completed stops.
- Wrap the timeline in DndContext + SortableContext with PointerSensor and KeyboardSensor; show a DragOverlay for the active item.
- Forward ref through TimelineItem so the dnd transform applies on the actual item node.